### PR TITLE
Refactor Behaviour and Handler, and fix the nodeinfo.client example blocking issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,17 +129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,12 +957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,7 +1063,6 @@ name = "examples"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "futures",
  "libp2p",
@@ -1362,15 +1344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,7 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1697,12 +1670,9 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
- "libp2p-identify",
  "libp2p-identity",
  "libp2p-mdns",
- "libp2p-metrics",
  "libp2p-noise",
- "libp2p-ping",
  "libp2p-quic",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -1795,28 +1765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-identify"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5455f472243e63b9c497ff320ded0314254a9eb751799a39c283c6f20b793f3c"
-dependencies = [
- "asynchronous-codec",
- "either",
- "futures",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "log",
- "lru",
- "quick-protobuf",
- "quick-protobuf-codec",
- "smallvec",
- "thiserror",
- "void",
-]
-
-[[package]]
 name = "libp2p-identity"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,19 +1804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-metrics"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
-dependencies = [
- "libp2p-core",
- "libp2p-identify",
- "libp2p-ping",
- "libp2p-swarm",
- "prometheus-client",
-]
-
-[[package]]
 name = "libp2p-noise"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,23 +1824,6 @@ dependencies = [
  "thiserror",
  "x25519-dalek 1.1.1",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-ping"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e57759c19c28a73ef1eb3585ca410cefb72c1a709fcf6de1612a378e4219202"
-dependencies = [
- "either",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core",
- "libp2p-swarm",
- "log",
- "rand 0.8.5",
- "void",
 ]
 
 [[package]]
@@ -2074,15 +1992,6 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
-
-[[package]]
-name = "lru"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
-dependencies = [
- "hashbrown 0.13.2",
-]
 
 [[package]]
 name = "lru-cache"
@@ -2690,29 +2599,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,6 @@ name = "nodeinfo-client"
 path = "bin/nodeinfo/client.rs"
 
 [dependencies]
-async-trait = "0.1"
 anyhow = { version = "1" }
 tracing = { version = "0.1.16" }
 tracing-subscriber = { version = "0.3", features = ["tracing-log", "fmt"] }
@@ -30,8 +29,6 @@ libp2p = { version = "0.51", features = [
     "noise",
     "tcp",
     "yamux",
-    "identify",
-    "ping",
 ] }
 clap = { version = "4.2", features = ["derive"] }
 libp2p-grpc-rs = { path = "../" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod adapter;
 mod behaviour;
 mod handler;
+mod protocol;
 
-pub use behaviour::{Behaviour, Event};
-
-pub const DEFAULT_PROTOCOL_NAME: &[u8] = b"/libp2p/grpc/1.0.0";
+pub use behaviour::{Behaviour, Event, GrpcOutbound, OutboundError};
+pub(crate) use protocol::{InboundId, InboundIdGen, OutboundId, OutboundRequest};
 
 const EMPTY_QUEUE_SHRINK_THRESHOLD: usize = 100;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,0 +1,135 @@
+use crate::{adapter, OutboundError};
+use futures::{channel::oneshot, future};
+use libp2p::{
+    core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo},
+    identity::PeerId,
+    swarm::NegotiatedSubstream,
+};
+use std::{
+    fmt, io, iter, ops,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+pub const DEFAULT_PROTOCOL_NAME: &[u8] = b"/libp2p/grpc/1.0.0";
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct OutboundId(u64);
+
+impl OutboundId {
+    pub fn new(n: u64) -> Self {
+        Self(n)
+    }
+}
+
+impl Default for OutboundId {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
+impl fmt::Display for OutboundId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl ops::AddAssign<u64> for OutboundId {
+    fn add_assign(&mut self, rhs: u64) {
+        self.0 += rhs
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct InboundId(u64);
+
+impl InboundId {
+    pub fn new(n: u64) -> Self {
+        Self(n)
+    }
+}
+
+impl Default for InboundId {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
+impl fmt::Display for InboundId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl ops::AddAssign<u64> for InboundId {
+    fn add_assign(&mut self, rhs: u64) {
+        self.0 += rhs
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InboundIdGen {
+    n: Arc<AtomicU64>,
+}
+
+impl InboundIdGen {
+    pub fn new(start: u64) -> Self {
+        Self {
+            n: Arc::new(AtomicU64::new(start)),
+        }
+    }
+    pub fn next(&self) -> InboundId {
+        InboundId::new(self.n.fetch_add(1, Ordering::SeqCst))
+    }
+}
+
+impl Default for InboundIdGen {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+unsafe impl Send for InboundIdGen {}
+
+#[derive(Debug)]
+pub struct OutboundRequest {
+    pub(crate) peer: PeerId,
+    pub(crate) outbound_id: OutboundId,
+    pub(crate) sender: oneshot::Sender<Result<adapter::Channel, OutboundError>>,
+}
+
+#[derive(Debug)]
+pub struct DirectGrpcUpgradeProtocol {
+    pub(crate) protocol_name: String,
+}
+
+impl UpgradeInfo for DirectGrpcUpgradeProtocol {
+    type Info = String;
+    type InfoIter = iter::Once<String>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        iter::once(self.protocol_name.clone())
+    }
+}
+
+impl OutboundUpgrade<NegotiatedSubstream> for DirectGrpcUpgradeProtocol {
+    type Output = NegotiatedSubstream;
+    type Error = io::Error;
+    type Future = future::Ready<Result<Self::Output, Self::Error>>;
+
+    fn upgrade_outbound(self, stream: NegotiatedSubstream, _: Self::Info) -> Self::Future {
+        future::ready(Ok(stream))
+    }
+}
+
+impl InboundUpgrade<NegotiatedSubstream> for DirectGrpcUpgradeProtocol {
+    type Output = NegotiatedSubstream;
+    type Error = io::Error;
+    type Future = future::Ready<Result<Self::Output, Self::Error>>;
+
+    fn upgrade_inbound(self, stream: NegotiatedSubstream, _: Self::Info) -> Self::Future {
+        future::ready(Ok(stream))
+    }
+}


### PR DESCRIPTION
* Rewrite outbound logic to move Channel building from Handler to Behaviour
* Redefine the get gRPC Channel method: instead of asynchronous to synchronous, return the type of handle to get the Channel
* Add InboundId for inbound flows (intentionally separate from OutboundId, mimicking rust-libp2p request-response protocol)
* Enriched Behaviour to expose events to the outside world, including handling internal errors (mimicking rust-libp2p request-response protocol)
* Fixed nodeinfo/client.rs example blocking: there are waiting requests in the drive loop for swarm events that depend on their events